### PR TITLE
Cleaning up the RAML file to reflect the current API.

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -44,10 +44,20 @@ version: v1
 /test:
     post:
         description: Check if the PhotoBackup server has been correctly configured.
+        body:
+            multipart/form-data:
+                formParameters:
+                    password:
+                        displayName: Password hash
+                        description: An SHA512 hash of the password.
+                        pattern: "[a-f0-9]{128}"
+                        example: 3bb12eda3c298db5de25597f54d924f2e17e78a26ad8953ed8218ee682f0bbbe9021e2f3009d152c911bf1f25ec683a902714166767afbd8e5bd0fb0124ecb8a
+                        required: true
+                        type: string
         responses:
-            200: OK
-            400: "missing file size in the request!"
-            401: "no file in the request!"
-            403: "wrong password!"
-            411: "file sizes do not match!"
-            500: server error
+            200:
+                description: The PhotoBackup server is ready to use.
+            403:
+                description: The provided password does not match the server password.
+            500:
+                description: The media folder does not exist on the server, or is unwritable to by PhotoBackup.

--- a/api.raml
+++ b/api.raml
@@ -2,18 +2,10 @@
 
 title: PhotoBackup
 version: v1
-traits:
-    - secured:
-        queryParameters:
-            password:
-                description: The server password
-                required: true
-                type: string
 
 /:
     post:
         description: Create a new picture to the collection.
-        is: [ secured ]
         body:
             multipart/form-data:
                 formParameters:
@@ -25,6 +17,10 @@ traits:
                         description: The size in bytes of the uploaded file.
                         required: true
                         type: integer
+                    password:
+                        description: The server password
+                        required: true
+                        type: string
         responses:
             200: "Test succeeded \o/"
             403: "wrong password!"
@@ -32,7 +28,6 @@ traits:
 
 
 /test:
-    is: [ secured ]
     post:
         description: Create a test result.
         responses:

--- a/api.raml
+++ b/api.raml
@@ -5,7 +5,7 @@ version: v1
 
 /:
     post:
-        description: Create a new picture to the collection.
+        description: Upload a photo to the server.
         body:
             multipart/form-data:
                 formParameters:
@@ -29,7 +29,7 @@ version: v1
 
 /test:
     post:
-        description: Create a test result.
+        description: Check if the PhotoBackup server has been correctly configured.
         responses:
             200: OK
             400: "missing file size in the request!"

--- a/api.raml
+++ b/api.raml
@@ -13,17 +13,18 @@ traits:
 /:
     post:
         description: Create a new picture to the collection.
-        queryParameters:
-            upfile:
-                description: The photo to backup
-                required: true
-                type: file
-            filesize:
-                description: The size in bytes of the uploaded file.
-                required: true
-                type: integer
         is: [ secured ]
         body:
+            multipart/form-data:
+                formParameters:
+                    upfile:
+                        description: The photo to backup
+                        required: true
+                        type: file
+                    filesize:
+                        description: The size in bytes of the uploaded file.
+                        required: true
+                        type: integer
         responses:
             200: "Test succeeded \o/"
             403: "wrong password!"

--- a/api.raml
+++ b/api.raml
@@ -11,11 +11,6 @@ traits:
                 type: string
 
 /:
-    get:
-        description: Redirect to official PhotoBackup website.
-        responses:
-            302: redirection to https://photobackup.github.io/
-
     post:
         description: Create a new picture to the collection.
         queryParameters:

--- a/api.raml
+++ b/api.raml
@@ -27,7 +27,7 @@ traits:
             filesize:
                 description: The size in bytes of the uploaded file.
                 required: true
-                type: int
+                type: integer
         body:
         responses:
             200: "Test succeeded \o/"

--- a/api.raml
+++ b/api.raml
@@ -28,10 +28,18 @@ version: v1
                         required: true
                         type: string
         responses:
-            200: "Test succeeded \o/"
-            403: "wrong password!"
-            500: "MEDIA_ROOT does not exist!" or "Can't write to MEDIA_ROOT!"
-
+            200:
+                description: The photo is successfully stored by PhotoBackup.
+            400:
+                description: The client did not provide a `filesize` parameter.
+            401:
+                description: The client did not provide a photo file.
+            403:
+                description: The provided password does not match the server password.
+            411:
+                description: The provided photo file has a different size than what the client provided in the `filesize` parameter.
+            500:
+                description: The media folder does not exist on the server, or is unwritable to by PhotoBackup.
 
 /test:
     post:

--- a/api.raml
+++ b/api.raml
@@ -16,7 +16,6 @@ traits:
         responses:
             302: redirection to https://photobackup.github.io/
 
-    is: [ secured ]
     post:
         description: Create a new picture to the collection.
         queryParameters:
@@ -28,6 +27,7 @@ traits:
                 description: The size in bytes of the uploaded file.
                 required: true
                 type: integer
+        is: [ secured ]
         body:
         responses:
             200: "Test succeeded \o/"

--- a/api.raml
+++ b/api.raml
@@ -10,15 +10,21 @@ version: v1
             multipart/form-data:
                 formParameters:
                     upfile:
-                        description: The photo to backup
+                        displayName: Photo
+                        description: The photo file that needs to be stored by PhotoBackup.
                         required: true
                         type: file
                     filesize:
-                        description: The size in bytes of the uploaded file.
+                        displayName: Photo size
+                        description: The size of the photo file, in bytes.
+                        example: 1024
                         required: true
                         type: integer
                     password:
-                        description: The server password
+                        displayName: Password hash
+                        description: An SHA512 hash of the password.
+                        pattern: "[a-f0-9]{128}"
+                        example: 3bb12eda3c298db5de25597f54d924f2e17e78a26ad8953ed8218ee682f0bbbe9021e2f3009d152c911bf1f25ec683a902714166767afbd8e5bd0fb0124ecb8a
                         required: true
                         type: string
         responses:

--- a/api.raml
+++ b/api.raml
@@ -45,7 +45,7 @@ version: v1
     post:
         description: Check if the PhotoBackup server has been correctly configured.
         body:
-            multipart/form-data:
+            application/x-www-form-urlencoded:
                 formParameters:
                     password:
                         displayName: Password hash


### PR DESCRIPTION
I have not squashed the commits, so you can see – step-by-step – what I have changed. In short:
1. `queryParameters` is gone. PhotoBackup does not send data as part of the URL, everything is always part of the post body. `formParameters` replaces it.
2. More explicit descriptions for everything.
3. In RAML, responses are always described with YAML maps for every status code. Not a string.

As I have started work on my PHP implementation again, I really wanted a solid API base to work from. Let me know what you think!

It should be 100% backwards compatible, thus the version number has not changed. The status codes were crossed referenced with [PhotoBackup/server-bottle](https://github.com/PhotoBackup/server-bottle).
