### PR TITLE
Clarify 401 and 403.

### DIFF
--- a/v2/api.raml
+++ b/v2/api.raml
@@ -61,7 +61,7 @@ version: v2
             200:
                 description: The PhotoBackup server is ready to use.
             401:
-                description: No password has been provided.
+                description: No server password has been configured.
             403:
                 description: The provided password does not match the server password.
             500:

--- a/v2/api.raml
+++ b/v2/api.raml
@@ -36,7 +36,7 @@ version: v2
             401:
                 description: The client did not provide a photo file.
             403:
-                description: The provided password does not match the server password.
+                description: No password was provided, or it does not match the server password.
             409:
                 description: The file exists and is complete.
             411:
@@ -63,6 +63,6 @@ version: v2
             401:
                 description: No server password has been configured.
             403:
-                description: The provided password does not match the server password.
+                description: No password was provided, or it does not match the server password.
             500:
                 description: The media folder does not exist on the server, or is unwritable to by PhotoBackup.


### PR DESCRIPTION
These are small tweaks to the description of 401 (for `/test`) and 403 (for both `/` and `/test`) in the most NON-BREAKING way possible.
1. When the client forgets to send a password, or sends an empty password, the server should respond with a `403 Forbidden`.
2. When the client is testing the server configuration (`/test`) respond with a `401 Unauthorized` in case no password has been configured by the server.
   
   Also note that this is **only** defined for `/test` and servers should **not** respond with `401 Unauthorized` when a client is trying to upload an image to `/`.

[PhotoBackup/server-php](https://github.com/PhotoBackup/server-php) already [adhere to this](https://github.com/PhotoBackup/server-php/blob/02928ff6b8943bc425122bf4ef9162464bbcfcde/index.php#L60-L75). The Python implementation does not: PhotoBackup/server-bottle#8.

These are the **wrong** HTTP status code, e.g. `401 Unauthorized` should be used where `403 Forbidden` is used. This pull to API v2 does not change any codes because it should be NON-BREAKING. (API v3 should fix this.) See PhotoBackup/api#2 for more discussion and planning for v3 (which will be BREAKING).
